### PR TITLE
Use docker-compose setup on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: ruby
+sudo: required
+addons:
+  apt:
+    sources:
+      - sourceline: "deb http://archive.ubuntu.com/ubuntu/ trusty universe"
+    packages:
+      - haveged
+services:
+  - docker
 cache:
   bundler: true
   directories:
     - $HOME/.m2
+before_script:
+  - docker-compose -p kafka-clients-jruby -f spec/resources/docker-compose.yml up -d
 script: bundle exec rake
 rvm:
-  - jruby-19mode
   - jruby-9.1.2.0
+  - jruby-1.7


### PR DESCRIPTION
This pull request updates the Travis configuration to use `docker-compose` setup, and some explanation for the changes:
- Set project name for docker-compose
  Otherwise it'll default to `resources_default`, and while not a problem on Travis it might pose a problem locally if multiple projects have their docker-compose.yml in a directory called `resources`.
- Use the apt addon to install `haveged`
  There's some [issues with JRuby and entropy](https://github.com/jruby/jruby/wiki/Improving-startup-time#ensure-your-system-has-adequate-entropy), and sometimes (for uncertain reasons), `bundle install` takes more than 10 minutes to even start. `haveged` makes sure that there's sufficient entropy for JRuby to not choke.
