### PR TITLE
Add RetriableError

### DIFF
--- a/ext/src/main/java/io/burt/kafka/clients/KafkaClients.java
+++ b/ext/src/main/java/io/burt/kafka/clients/KafkaClients.java
@@ -1,6 +1,7 @@
 package io.burt.kafka.clients;
 
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.RetriableException;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -40,7 +41,9 @@ public class KafkaClients {
         try {
           Class<?> exceptionClass = Class.forName(String.format("%s.%s", packageName, javaName));
           String baseClassName = "Kafka::Clients::KafkaError";
-          if (ApiException.class.isAssignableFrom(exceptionClass)) {
+          if (RetriableException.class.isAssignableFrom(exceptionClass)) {
+            baseClassName = "Kafka::Clients::RetriableError";
+          } else if (ApiException.class.isAssignableFrom(exceptionClass)) {
             baseClassName = "Kafka::Clients::ApiError";
           }
           return module.defineClassUnder(rubyName, (RubyClass) ctx.runtime.getClassFromPath(baseClassName), ctx.runtime.getStandardError().getAllocator());

--- a/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
+++ b/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
@@ -49,7 +49,8 @@ public class KafkaClientsLibrary implements Library {
   private void installErrors(Ruby runtime, RubyModule parentModule) {
     RubyClass standardErrorClass = runtime.getStandardError();
     RubyClass kafkaErrorClass = parentModule.defineClassUnder("KafkaError", standardErrorClass, standardErrorClass.getAllocator());
-    parentModule.defineClassUnder("ApiError", kafkaErrorClass, standardErrorClass.getAllocator());
+    RubyClass apiErrorClass = parentModule.defineClassUnder("ApiError", kafkaErrorClass, standardErrorClass.getAllocator());
+    parentModule.defineClassUnder("RetriableError", apiErrorClass, standardErrorClass.getAllocator());
   }
 
   static RubyClass mapErrorClass(Ruby runtime, Throwable t) {

--- a/spec/kafka/clients/misc_spec.rb
+++ b/spec/kafka/clients/misc_spec.rb
@@ -19,6 +19,13 @@ module Kafka
       end
     end
 
+    it 'makes RetriableExceptions subclasses of RetriableError' do
+      aggregate_failures do
+        expect(described_class::DisconnectError.ancestors).to include(described_class::RetriableError)
+        expect(described_class::InvalidMetadataError.ancestors).to include(described_class::RetriableError)
+      end
+    end
+
     it 'does not generate an error class when there is no corresponding error in Kafka' do
       expect { described_class::FuzzBazzError }.to raise_error(NameError)
     end


### PR DESCRIPTION
[`RetrieableException`](https://kafka.apache.org/0102/javadoc/org/apache/kafka/common/errors/RetriableException.html) is a sub class to `ApiException`. This pull request adds a `RetriableError` wrapper, so we can catch only those errors.