### PR TITLE
Fix future timeout option

### DIFF
--- a/ext/src/main/java/io/burt/kafka/clients/FutureWrapper.java
+++ b/ext/src/main/java/io/burt/kafka/clients/FutureWrapper.java
@@ -77,7 +77,7 @@ public class FutureWrapper<T> extends RubyObject implements Future<IRubyObject> 
     long timeout = -1;
     if (args.length > 0) {
       RubyHash options = args[0].convertToHash();
-      IRubyObject timeoutOption = options.fastARef(ctx.runtime.newString("timeout"));
+      IRubyObject timeoutOption = options.fastARef(ctx.runtime.newSymbol("timeout"));
       if (timeoutOption!= null && !timeoutOption.isNil()) {
         timeout = (long) Math.floor(timeoutOption.convertToFloat().getDoubleValue() * 1000);
       }

--- a/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
+++ b/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaException;
+import java.util.concurrent.TimeoutException;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -58,6 +59,8 @@ public class KafkaClientsLibrary implements Library {
       String javaName = t.getClass().getSimpleName();
       String rubyName = javaName.substring(0, javaName.length() - 9) + "Error";
       return (RubyClass) runtime.getClassFromPath(String.format("Kafka::Clients::%s", rubyName));
+    } else if (t instanceof TimeoutException) {
+      return (RubyClass) runtime.getModule("Timeout").getConstant("Error");
     } else {
       return runtime.getStandardError();
     }

--- a/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
+++ b/ext/src/main/java/io/burt/kafka/clients/KafkaClientsLibrary.java
@@ -52,6 +52,7 @@ public class KafkaClientsLibrary implements Library {
     RubyClass kafkaErrorClass = parentModule.defineClassUnder("KafkaError", standardErrorClass, standardErrorClass.getAllocator());
     RubyClass apiErrorClass = parentModule.defineClassUnder("ApiError", kafkaErrorClass, standardErrorClass.getAllocator());
     parentModule.defineClassUnder("RetriableError", apiErrorClass, standardErrorClass.getAllocator());
+    parentModule.defineClassUnder("TimeoutError", standardErrorClass, standardErrorClass.getAllocator());
   }
 
   static RubyClass mapErrorClass(Ruby runtime, Throwable t) {
@@ -60,7 +61,7 @@ public class KafkaClientsLibrary implements Library {
       String rubyName = javaName.substring(0, javaName.length() - 9) + "Error";
       return (RubyClass) runtime.getClassFromPath(String.format("Kafka::Clients::%s", rubyName));
     } else if (t instanceof TimeoutException) {
-      return (RubyClass) runtime.getModule("Timeout").getConstant("Error");
+      return (RubyClass) runtime.getClassFromPath("Kafka::Clients::TimeoutError");
     } else {
       return runtime.getStandardError();
     }

--- a/spec/kafka/clients/producer_spec.rb
+++ b/spec/kafka/clients/producer_spec.rb
@@ -148,7 +148,7 @@ module Kafka
 
           it 'raises a timeout if operation takes longer time than timeout option' do
             future = producer.send('toptopic', 0, time, 'hello', 'world')
-            expect { future.get(timeout: 0.1) }.to raise_error(Timeout::Error)
+            expect { future.get(timeout: 0.1) }.to raise_error(Kafka::Clients::TimeoutError)
           end
         end
 

--- a/spec/kafka/clients/producer_spec.rb
+++ b/spec/kafka/clients/producer_spec.rb
@@ -145,6 +145,11 @@ module Kafka
               expect(metadata.serialized_value_size).to be_a(Fixnum)
             end
           end
+
+          it 'raises a timeout if operation takes longer time than timeout option' do
+            future = producer.send('toptopic', 0, time, 'hello', 'world')
+            expect { future.get(timeout: 0.1) }.to raise_error(Timeout::Error)
+          end
         end
 
         it 'accepts a block that will be called when the record has been saved' do


### PR DESCRIPTION
The documentation for `Future.get` specifies a `:timeout` symbol, but the code actually looked for a string. This pull request switches to properly using the symbol, and adds a test to verify this. It also converts `java.util.concurrent.TimeoutException` to `Timeout::Error`, allowing for more fine tuned rescues.